### PR TITLE
Default sentence expansion for Word Card via CSS variable

### DIFF
--- a/Template/front.html
+++ b/Template/front.html
@@ -160,5 +160,36 @@
     }
   }
 
+  // Shows or hides the word card sentence based on CSS variables
+  function initializeSentenceState() {
+    const wrapper = document.getElementById('sentence-wrapper');
+    const innerElement = document.getElementById('sentence');
+
+    if (wrapper && innerElement) {
+      const expandByDefault = getComputedStyle(document.documentElement)
+                              .getPropertyValue('--word-sentence-default-expanded').trim();
+
+      if (expandByDefault === 'true') {
+        const originalWrapperTransition = wrapper.style.transition;
+        const originalInnerElementTransition = innerElement.style.transition;
+
+        wrapper.style.transition = 'none';
+        innerElement.style.transition = 'none';
+
+        requestAnimationFrame(() => {
+            const scrollHeight = innerElement.scrollHeight + 'px';
+            wrapper.style.maxHeight = scrollHeight;
+            wrapper.classList.add('expanded');
+
+            requestAnimationFrame(() => {
+                wrapper.style.transition = originalWrapperTransition;
+                innerElement.style.transition = originalInnerElementTransition;
+            });
+        });
+      }
+    }
+  }
+
   initializeAudioSentenceState();
+  initializeSentenceState();
 </script>	

--- a/Template/styling.css
+++ b/Template/styling.css
@@ -71,6 +71,7 @@
   
   /* ===== LAYOUT & SPACING ===== */
   /* Default States */
+  --word-sentence-default-expanded:  false;  /* "true" to show sentence on word cards immediately */  
   --audio-sentence-default-expanded: false; /* "true" to show sentence on audio cards immediately */
   --notes-default-expanded:          false; /* "true" to show notes immediately */
   --collect-glossary-images:         true;  /* "false" to disable image collection */


### PR DESCRIPTION
- Added new CSS variable `--word-sentence-default-expanded` to control sentence visibility on word card front.
- Implemented `initializeSentenceState()` in front template to auto-expand `#sentence-wrapper` when variable is set to `true`.
- Logic mirrors `initializeAudioSentenceState()` for consistent behavior.
- Preserves existing click-to-expand functionality for manual interaction.

Resolves BrenoAqua/Senren#18