### PR TITLE
Update default separator in join_field_content

### DIFF
--- a/resources/subs2srs.lua
+++ b/resources/subs2srs.lua
@@ -323,7 +323,7 @@ end
 
 local function join_field_content(new_text, old_text, separator)
     -- By default, join fields with a HTML newline.
-    separator = separator or "<br>"
+    separator = separator or ""
 
     if h.is_empty(old_text) then
         -- If 'old_text' is empty, there's no need to join content with the separator.


### PR DESCRIPTION
Change default separator in join_field_content function to an empty string.