### PR TITLE
Enhance image collection to include definition field images

### DIFF
--- a/Template/back.html
+++ b/Template/back.html
@@ -259,7 +259,7 @@
 
   // Collect images from the glossary and add them to the picture container
   function collectGlossaryImages() {
-    const glossaryItems = document.querySelectorAll("#glossary img");
+    const glossaryItems = document.querySelectorAll("#glossary img, #definition img");
     const pictureContainer = document.querySelector(".picture-container");
 
     if (!glossaryItems.length || !pictureContainer) return;
@@ -270,8 +270,15 @@
     if (collectSetting !== 'true') {
       return;
     }
-
+    
+    const existingSrcs = new Set(
+      Array.from(pictureContainer.querySelectorAll('img')).map(img => img.src)
+    );
+    
     glossaryItems.forEach(img => {
+      if (!img.src || existingSrcs.has(img.src)) {
+      return;
+      }
       if (!img.src ||
         img.src === window.location.href ||
         img.src.toLowerCase().endsWith('.svg') ||
@@ -283,6 +290,8 @@
       ) {
         return;
       }
+
+      existingSrcs.add(img.src);
 
       const aspectRatio = img.naturalWidth / img.naturalHeight;
       const tooTall = aspectRatio < 0.7;


### PR DESCRIPTION
Collecting images from dictionaries only works when they are in the `glossary` field in Anki.

For my use case, I use the JPMN style handlebars and put `{primary-definition}` in the `definition` field, which could be a monolingual dictionary with images that I also want included in the lightbox, so added `#definition img` to `glossaryItems`

But for those that use `{single-glossary-○○}` in `definition` field and `{glossary}` in the `glossary` field, you could potentially get duplicate dictionary entries and therefore duplicate images collected in the lightbox. Therefore I added some logic to exclude duplicates.