### PR TITLE
Additional CSS selectors for <strong> and <em>

### DIFF
--- a/Template/styling.css
+++ b/Template/styling.css
@@ -634,13 +634,13 @@ a {
 }
 
 /* Highlight Text */
-b {
+:is(b, strong) {
   color: var(--light-highlight);
   font-weight: normal;
 }
 
 :is(.card.nightMode, .custom-dark-mode) 
-b {
+:is(b, strong) {
   color: var(--dark-highlight);
 }
 
@@ -2166,7 +2166,7 @@ span[style*="display:inline"]:has(+ span[style*="border:1.5px dotted #c83c28"]) 
   }
 }
 
-.yomitan-glossary:has(.dictionary-title) i {
+.yomitan-glossary:has(.dictionary-title) :is(i, em) {
   display: none !important;
 }
 


### PR DESCRIPTION
Tiny tweak to handle `<strong>` for highlighting, and `<em>` for hiding dictionary title in niche cases. I was using https://html-cleaner.com/ to help de-bloat some unnecessary dictionary styling for certain cases but it always reformatted italic and bold to emphasis and strong and it was a pain to keep changing it back. Probably a very niche case, but seems harmless to add.